### PR TITLE
Remove labels and syncset on inventory deletion or disassociation.

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -55,6 +55,7 @@ rules:
   - create
   - update
   - watch
+  - delete
 - apiGroups:
   - apps
   resourceNames:


### PR DESCRIPTION
spec.clusterName is used to associate an inventory with a cluster.
If the clusterName is removed, the corresponding resources in the managed
cluster must be deleted. If the inventory itself is deleted, corresponding
resources in the managed cluster must also be deleted.