### PR TITLE
chore: add condition for syncset creation

### DIFF
--- a/pkg/apis/midas/v1alpha1/baremetalasset_types.go
+++ b/pkg/apis/midas/v1alpha1/baremetalasset_types.go
@@ -81,11 +81,10 @@ const (
 	// of a BareMetalAsset have been found.
 	ConditionCredentialsFound conditionsv1.ConditionType = "CredentialsFound"
 
-	// ConditionSyncSetCreated reports whether the SyncSet for a given
-	// BareMetalAsset has been created.
-	ConditionSyncSetCreated conditionsv1.ConditionType = "SyncSetCreated"
+	// ConditionAssetSyncStarted reports whether syncronization of a BareMetalHost
+	// to a managed cluster has started
+	ConditionAssetSyncStarted conditionsv1.ConditionType = "AssetSyncStarted"
 )
-
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/apis/midas/v1alpha1/baremetalasset_types.go
+++ b/pkg/apis/midas/v1alpha1/baremetalasset_types.go
@@ -75,9 +75,17 @@ type BareMetalAssetStatus struct {
 	RelatedObjects []corev1.ObjectReference `json:"relatedObjects,omitempty"`
 }
 
-// ConditionCredentialsFound reports whether the secret containing the credentials
-// of a BareMetalAsset have been found.
-const ConditionCredentialsFound conditionsv1.ConditionType = "CredentialsFound"
+// Condition Types
+const (
+	// ConditionCredentialsFound reports whether the secret containing the credentials
+	// of a BareMetalAsset have been found.
+	ConditionCredentialsFound conditionsv1.ConditionType = "CredentialsFound"
+
+	// ConditionSyncSetCreated reports whether the SyncSet for a given
+	// BareMetalAsset has been created.
+	ConditionSyncSetCreated conditionsv1.ConditionType = "SyncSetCreated"
+)
+
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/controller/baremetalasset/baremetalasset_controller.go
+++ b/pkg/controller/baremetalasset/baremetalasset_controller.go
@@ -199,14 +199,32 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetal
 	hsc := r.newHiveSyncSet(bma, reqLogger)
 
 	found := &hivev1.SyncSet{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: hsc.Name, Namespace: bma.Namespace}, found)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: hsc.Name, Namespace: hsc.Namespace}, found)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			err := r.client.Create(context.TODO(), hsc)
 			if err != nil {
 				reqLogger.Error(err, "Failed to create Hive SyncSet")
+				conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
+					Type:    midasv1alpha1.ConditionSyncSetCreated,
+					Status:  corev1.ConditionFalse,
+					Reason:  "SyncSetCreationFailed",
+					Message: "Failed to create SyncSet",
+				})
+				// do not overwrite err
+				serr := r.client.Status().Update(context.TODO(), bma)
+				if serr != nil {
+					reqLogger.Error(serr, "Failed to update SyncSetCreated condition")
+				}
 				return err
 			}
+
+			conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
+				Type:    midasv1alpha1.ConditionSyncSetCreated,
+				Status:  corev1.ConditionTrue,
+				Reason:  "SyncSetCreated",
+				Message: "SyncSet created successfully",
+			})
 		} else {
 			// other error. fail reconcile
 			reqLogger.Error(err, "Failed to get Hive SyncSet")
@@ -222,10 +240,24 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetal
 				reqLogger.Error(err, "Failed to update Hive SyncSet")
 				return err
 			}
+			conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
+				Type:    midasv1alpha1.ConditionSyncSetCreated,
+				Status:  corev1.ConditionTrue,
+				Reason:  "SyncSetUpdated",
+				Message: "SyncSet updated successfully",
+			})
 		}
 	}
 
-	return nil
+	// Add SyncSet to related objects
+	hscRef, err := reference.GetReference(r.scheme, hsc)
+	if err != nil {
+		reqLogger.Error(err, "Failed to get reference from SyncSet")
+		return err
+	}
+	objectreferencesv1.SetObjectReference(&bma.Status.RelatedObjects, *hscRef)
+
+	return r.client.Status().Update(context.TODO(), bma)
 }
 
 func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) *hivev1.SyncSet {

--- a/pkg/controller/baremetalasset/baremetalasset_controller.go
+++ b/pkg/controller/baremetalasset/baremetalasset_controller.go
@@ -206,7 +206,7 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetal
 			if err != nil {
 				reqLogger.Error(err, "Failed to create Hive SyncSet")
 				conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-					Type:    midasv1alpha1.ConditionSyncSetCreated,
+					Type:    midasv1alpha1.ConditionAssetSyncStarted,
 					Status:  corev1.ConditionFalse,
 					Reason:  "SyncSetCreationFailed",
 					Message: "Failed to create SyncSet",
@@ -220,7 +220,7 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetal
 			}
 
 			conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-				Type:    midasv1alpha1.ConditionSyncSetCreated,
+				Type:    midasv1alpha1.ConditionAssetSyncStarted,
 				Status:  corev1.ConditionTrue,
 				Reason:  "SyncSetCreated",
 				Message: "SyncSet created successfully",
@@ -241,7 +241,7 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetal
 				return err
 			}
 			conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-				Type:    midasv1alpha1.ConditionSyncSetCreated,
+				Type:    midasv1alpha1.ConditionAssetSyncStarted,
 				Status:  corev1.ConditionTrue,
 				Reason:  "SyncSetUpdated",
 				Message: "SyncSet updated successfully",


### PR DESCRIPTION
Update conditions for when the syncset is successfully created (or not)
and add the syncset to our list of related objects if found.