### PR TITLE
Create resources in proper namespaces

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,9 +22,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: multicluster-inventory
@@ -56,6 +56,14 @@ rules:
   - update
   - watch
   - delete
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resourceNames:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,11 +1,12 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: multicluster-inventory
 subjects:
 - kind: ServiceAccount
   name: multicluster-inventory
+  namespace: default
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: multicluster-inventory
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/apis/midas/v1alpha1/baremetalasset_types.go
+++ b/pkg/apis/midas/v1alpha1/baremetalasset_types.go
@@ -6,6 +6,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ManagedClusterResourceNamespace is the namespace on the managed cluster where BareMetalHosts are placed.
+const ManagedClusterResourceNamespace string = "openshift-machine-api"
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
@@ -84,6 +87,10 @@ const (
 	// ConditionAssetSyncStarted reports whether syncronization of a BareMetalHost
 	// to a managed cluster has started
 	ConditionAssetSyncStarted conditionsv1.ConditionType = "AssetSyncStarted"
+
+	// ConditionClusterDeploymentFound reports whether the cluster deployment referenced in
+	// a BareMetalAsset has been found.
+	ConditionClusterDeploymentFound conditionsv1.ConditionType = "ClusterDeploymentFound"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/baremetalasset/baremetalasset_controller.go
+++ b/pkg/controller/baremetalasset/baremetalasset_controller.go
@@ -174,7 +174,6 @@ func (r *ReconcileBareMetalAsset) Reconcile(request reconcile.Request) (reconcil
 			reqLogger.Error(err, "Failed to update secret with OwnerReferences")
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{Requeue: true}, nil
 	}
 
 	// Update the cluster label from instance spec.clusterName
@@ -198,29 +197,72 @@ func (r *ReconcileBareMetalAsset) Reconcile(request reconcile.Request) (reconcil
 	}
 
 	if instance.Spec.ClusterName != "" {
-		// If clusterName is specified, ensure syncset is created
-		err = r.ensureHiveSyncSet(instance, reqLogger)
+		// If clusterName is specified in the spec, we need to find the clusterdeployment for that clusterName and create
+		// hive syncset in the same namespace as the clusterdeployment.
+		clusterName := instance.Spec.ClusterName
+		foundCd := &hivev1.ClusterDeployment{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: clusterName, Namespace: clusterName}, foundCd)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				reqLogger.Error(err, "ClusterDeployment not found", "Namespace", clusterName, "ClusterDeployment", clusterName)
+				conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+					Type:    midasv1alpha1.ConditionClusterDeploymentFound,
+					Status:  corev1.ConditionFalse,
+					Reason:  "ClusterDeploymentNotFound",
+					Message: fmt.Sprintf("A cluster deployment with the name %v in namespace %v could not be found", clusterName, clusterName),
+				})
+				return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
+			}
+			return reconcile.Result{}, err
+		}
+		conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+			Type:    midasv1alpha1.ConditionClusterDeploymentFound,
+			Status:  corev1.ConditionTrue,
+			Reason:  "ClusterDeploymentFound",
+			Message: fmt.Sprintf("A clusterdeployment with the name %v in namespace %v was found", clusterName, clusterName),
+		})
+		statusErr := r.client.Status().Update(context.TODO(), instance)
+		if statusErr != nil {
+			reqLogger.Error(statusErr, "Failed to update instance status")
+			return reconcile.Result{}, statusErr
+		}
+
+		// If clusterDeployment is found, ensure syncset is created
+		err = r.ensureHiveSyncSet(instance, foundCd, reqLogger)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 	} else {
-		// if clusterName is not specified, delete the syncset if it exists
-		found := &hivev1.SyncSet{}
-		err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, found)
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				reqLogger.Error(err, "Failed to get Hive SyncSet")
-				return reconcile.Result{}, err
-			}
-		} else {
-			err = r.client.Delete(context.TODO(), found)
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					reqLogger.Error(err, "Failed to delete Hive SyncSet")
-					return reconcile.Result{}, err
-				}
+		// Without a clusterName, we do not know what namespace the syncset is in.
+		// Get the syncset from relatedobjects if it exists
+		hscRef := corev1.ObjectReference{}
+		for _, ro := range instance.Status.RelatedObjects {
+			if ro.Name == instance.Name && ro.Kind == "SyncSet" && ro.APIVersion == hivev1.SchemeGroupVersion.String() {
+				hscRef = ro
+				break
 			}
 		}
+		if hscRef == (corev1.ObjectReference{}) {
+			// No syncset found in relatedObjects. Nothing to do.
+			return reconcile.Result{}, nil
+		}
+		// If clusterName is not specified, delete the syncset if it exists
+		reqLogger.Info("Cleaning up Hive SyncSet", "Name", hscRef.Name, "Namespace", hscRef.Namespace)
+		err = r.client.Delete(context.TODO(), &hivev1.SyncSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: hscRef.Name,
+				Name:      hscRef.Namespace,
+			},
+		})
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				reqLogger.Error(err, "Failed to delete Hive SyncSet")
+				return reconcile.Result{}, err
+			}
+		}
+		// Remove SyncSet from related objects
+		objectreferencesv1.RemoveObjectReference(&instance.Status.RelatedObjects, hscRef)
+		return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
 	}
 
 	reqLogger.Info("Reconciled")
@@ -228,8 +270,8 @@ func (r *ReconcileBareMetalAsset) Reconcile(request reconcile.Request) (reconcil
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) error {
-	hsc := r.newHiveSyncSet(bma, reqLogger)
+func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetalAsset, cd *hivev1.ClusterDeployment, reqLogger logr.Logger) error {
+	hsc := r.newHiveSyncSet(bma, cd, reqLogger)
 
 	found := &hivev1.SyncSet{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: hsc.Name, Namespace: hsc.Namespace}, found)
@@ -301,7 +343,7 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetal
 	}
 
 	// Add SyncSet to related objects
-	hscRef, err := reference.GetReference(r.scheme, hsc)
+	hscRef, err := reference.GetReference(r.scheme, found)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get reference from SyncSet")
 		return err
@@ -311,7 +353,7 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetal
 	return r.client.Status().Update(context.TODO(), bma)
 }
 
-func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) *hivev1.SyncSet {
+func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAsset, cd *hivev1.ClusterDeployment, reqLogger logr.Logger) *hivev1.SyncSet {
 	bmhResource, err := json.Marshal(r.newBareMetalHost(bma, reqLogger))
 	if err != nil {
 		reqLogger.Error(err, "Error marshaling baremetalhost")
@@ -328,7 +370,7 @@ func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAss
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bma.Name,
-			Namespace: bma.Namespace,
+			Namespace: cd.Namespace, // syncset should be created in the same namespace as the clusterdeployment
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
 					UID:                bma.UID,
@@ -348,7 +390,7 @@ func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAss
 					},
 				},
 				Patches:           []hivev1.SyncObjectPatch{},
-				ResourceApplyMode: hivev1.UpsertResourceApplyMode,
+				ResourceApplyMode: hivev1.SyncResourceApplyMode,
 				Secrets: []hivev1.SecretMapping{
 					hivev1.SecretMapping{
 						SourceRef: hivev1.SecretReference{
@@ -357,7 +399,7 @@ func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAss
 						},
 						TargetRef: hivev1.SecretReference{
 							Name:      bma.Spec.BMC.CredentialsName,
-							Namespace: bma.Namespace,
+							Namespace: midasv1alpha1.ManagedClusterResourceNamespace,
 						},
 					},
 				},
@@ -382,7 +424,7 @@ func (r *ReconcileBareMetalAsset) newBareMetalHost(bma *midasv1alpha1.BareMetalA
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bma.Name,
-			Namespace: bma.Namespace,
+			Namespace: midasv1alpha1.ManagedClusterResourceNamespace,
 		},
 		Spec: metal3v1alpha1.BareMetalHostSpec{
 			BMC: metal3v1alpha1.BMCDetails{

--- a/pkg/controller/baremetalasset/baremetalasset_controller.go
+++ b/pkg/controller/baremetalasset/baremetalasset_controller.go
@@ -80,6 +80,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to secondary resource ClusterDeployments and requeue the owner BareMetalAsset
+	err = c.Watch(&source.Kind{Type: &hivev1.ClusterDeployment{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &midasv1alpha1.BareMetalAsset{},
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controller/baremetalasset/baremetalasset_controller.go
+++ b/pkg/controller/baremetalasset/baremetalasset_controller.go
@@ -315,7 +315,7 @@ func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAss
 	hsc := &hivev1.SyncSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "SyncSet",
-			APIVersion: "hive.openshift.io/v1alpha1",
+			APIVersion: "hive.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bma.Name,


### PR DESCRIPTION
Major changes:
- Check ClusterDeployment exists for the clusterName
- Create BareMetalHosts in the managed cluster in the "openshift-machine-api" namespace. Fixes [#15](https://github.com/mhrivnak/multicluster-inventory/issues/15)
- Create Hive SyncSet in the hub cluster in the same namespace as ClusterDeployment.
- Change the operator to cluster-scoped, so the operator can run in the operator-namespace and manage syncsets in the clusterdeployment namespace.