### PR TITLE
Use name and namespace for ClusterDeployment in BMA Spec

### DIFF
--- a/deploy/crds/midas.io_baremetalassets_crd.yaml
+++ b/deploy/crds/midas.io_baremetalassets_crd.yaml
@@ -51,9 +51,9 @@ spec:
                 types, but required for libvirt VMs driven by vbmc.
               pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
               type: string
-            clusterName:
-              description: The name of the cluster which the host belongs to.
-              type: string
+            clusterDeployment:
+              description: ClusterDeployment which the asset belongs to.
+              type: object
             hardwareProfile:
               description: What is the name of the hardware profile for this host?
                 It should only be necessary to set this when inspection cannot automatically

--- a/deploy/crds/midas.io_v1alpha1_baremetalasset_cr.yaml
+++ b/deploy/crds/midas.io_v1alpha1_baremetalasset_cr.yaml
@@ -20,4 +20,6 @@ spec:
   bootMACAddress: "00:1B:44:11:3A:B7"
   hardwareProfile: "hardwareProfile"
   role: "worker"
-  clusterName: "cluster0"
+  clusterDeployment:
+    name: cluster0
+    namespace: cluster0

--- a/pkg/apis/midas/v1alpha1/baremetalasset_types.go
+++ b/pkg/apis/midas/v1alpha1/baremetalasset_types.go
@@ -59,8 +59,8 @@ type BareMetalAssetSpec struct {
 	// +kubebuilder:validation:Enum=master;worker
 	Role Role `json:"role,omitempty"`
 
-	// The name of the cluster which the host belongs to.
-	ClusterName string `json:"clusterName,omitempty"`
+	// ClusterDeployment which the asset belongs to.
+	ClusterDeployment metav1.ObjectMeta `json:"clusterDeployment,omitempty"`
 }
 
 // BareMetalAssetStatus defines the observed state of BareMetalAsset

--- a/pkg/apis/midas/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/midas/v1alpha1/zz_generated.deepcopy.go
@@ -31,7 +31,7 @@ func (in *BareMetalAsset) DeepCopyInto(out *BareMetalAsset) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 	return
 }
@@ -91,6 +91,7 @@ func (in *BareMetalAssetList) DeepCopyObject() runtime.Object {
 func (in *BareMetalAssetSpec) DeepCopyInto(out *BareMetalAssetSpec) {
 	*out = *in
 	out.BMC = in.BMC
+	in.ClusterDeployment.DeepCopyInto(&out.ClusterDeployment)
 	return
 }
 


### PR DESCRIPTION
Cluster Manager can create Hive ClusterDeployment with a name and namespace and this information has to be provided in the spec to associate a BMA with the clusterDeployment. ClusterName was not enough by itself because we would have to search for the cluster across all namespaces, and there may be multiple of them. This lets us uniquely identify the clusterDeployment.