### PR TITLE
Fix build-image target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ sanity: ## Check the sanity of the project
 	git diff --exit-code
 
 build: ## Build binary from source
-	go build -i ./cmd/manager/main.go
+	go build -i -o build/_output/bin/multicluster-inventory ./cmd/manager/main.go
 
 test: ## Unit test the project
 	go test -v ./...


### PR DESCRIPTION
"make build" should create build/_output/bin/multicluster-inventory.
At the moment it produces a binary named "main" in the pwd.

The Dockerfile expects build/_output/bin/multicluster-inventory to
exist.

Signed-off-by: Richard Su <rwsu@redhat.com>