### PR TITLE
refactor: modularize reconcile function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/kubernetes v1.16.2
 	sigs.k8s.io/controller-runtime v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -914,6 +914,7 @@ k8s.io/kube-state-metrics v1.7.2/go.mod h1:U2Y6DRi07sS85rmVPmBFlmv+2peBcL8IWGjM+
 k8s.io/kubectl v0.0.0-20191016120415-2ed914427d51/go.mod h1:gL826ZTIfD4vXTGlmzgTbliCAT9NGiqpCqK2aNYv5MQ=
 k8s.io/kubelet v0.0.0-20191016114556-7841ed97f1b2/go.mod h1:SBvrtLbuePbJygVXGGCMtWKH07+qrN2dE1iMnteSG8E=
 k8s.io/kubernetes v1.16.0/go.mod h1:nlP2zevWKRGKuaaVbKIwozU0Rjg9leVDXkL4YTtjmVs=
+k8s.io/kubernetes v1.16.2 h1:k0f/OVp6Yfv+UMTm6VYKhqjRgcvHh4QhN9coanjrito=
 k8s.io/kubernetes v1.16.2/go.mod h1:SmhGgKfQ30imqjFVj8AI+iW+zSyFsswNErKYeTfgoH0=
 k8s.io/legacy-cloud-providers v0.0.0-20191016115753-cf0698c3a16b/go.mod h1:tKW3pKqdRW8pMveUTpF5pJuCjQxg6a25iLo+Z9BXVH0=
 k8s.io/metrics v0.0.0-20191016113814-3b1a734dba6e/go.mod h1:ve7/vMWeY5lEBkZf6Bt5TTbGS3b8wAxwGbdXAsufjRs=

--- a/pkg/controller/baremetalasset/baremetalasset_controller.go
+++ b/pkg/controller/baremetalasset/baremetalasset_controller.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/go-logr/logr"
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 	midasv1alpha1 "github.com/mhrivnak/multicluster-inventory/pkg/apis/midas/v1alpha1"
+	bmaerrors "github.com/mhrivnak/multicluster-inventory/pkg/errors"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
@@ -19,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/reference"
+	k8slabels "k8s.io/kubernetes/pkg/util/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -40,6 +43,11 @@ const (
 	ClusterDeploymentNamespaceLabel = "metal3.io/cluster-deployment-namespace"
 	// BareMetalHostKind contains the value of kind BareMetalHost
 	BareMetalHostKind = "BareMetalHost"
+)
+
+const (
+	// assetSecretRequeueAfter specifies the amount of time, in seconds, before requeue
+	assetSecretRequeueAfter int = 60
 )
 
 // Add creates a new BareMetalAsset Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -159,116 +167,118 @@ func (r *ReconcileBareMetalAsset) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	// Check if the secret exists
+	for _, f := range []func(*midasv1alpha1.BareMetalAsset, logr.Logger) error{
+		r.checkAssetSecret,
+		r.ensureLabels,
+		r.checkClusterDeployment,
+		r.ensureHiveSyncSet,
+		r.checkHiveSyncSetInstance,
+	} {
+		err = f(instance, reqLogger)
+		if err != nil {
+			switch {
+			case bmaerrors.IsNoClusterError(err):
+				reqLogger.Info("No cluster specified")
+				return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
+			case bmaerrors.IsAssetSecretNotFoundError(err):
+				// since we won't be notified when the secret is created, requeue after some time
+				reqLogger.Info("Secret not found", "RequeueAfter.Duration", fmt.Sprintf("%v seconds", assetSecretRequeueAfter))
+				return reconcile.Result{RequeueAfter: time.Duration(assetSecretRequeueAfter) * time.Second}, r.client.Status().Update(context.TODO(), instance)
+			}
+
+			reqLogger.Error(err, "Failed reconcile")
+			statusErr := r.client.Status().Update(context.TODO(), instance)
+			if statusErr != nil {
+				reqLogger.Error(statusErr, "Failed to update status")
+			}
+
+			return reconcile.Result{}, err
+		}
+	}
+
+	reqLogger.Info("Reconciled")
+	return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
+}
+
+// checkAssetSecret verifies that we can find the secret listed in the BareMetalAsset
+func (r *ReconcileBareMetalAsset) checkAssetSecret(instance *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) error {
 	secretName := instance.Spec.BMC.CredentialsName
+
 	secret := &corev1.Secret{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: request.Namespace}, secret)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: instance.Namespace}, secret)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			reqLogger.Error(err, "Secret not found", "Namespace", request.Namespace, "Secret.Name", secretName)
+			reqLogger.Error(err, "Secret not found", "Secret.Name", secretName, "Secret.Namespace", instance.Namespace)
 			conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
 				Type:    midasv1alpha1.ConditionCredentialsFound,
 				Status:  corev1.ConditionFalse,
 				Reason:  "SecretNotFound",
-				Message: fmt.Sprintf("A secret with the name %v in namespace %v could not be found", secretName, request.Namespace),
+				Message: err.Error(),
 			})
-			return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
+			return bmaerrors.NewAssetSecretNotFoundError(secretName, instance.Namespace)
 		}
-		return reconcile.Result{}, err
+		return err
 	}
 
-	// Turn the secret into a reference we can use in status
+	// add secret reference to status
 	secretRef, err := reference.GetReference(r.scheme, secret)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get reference from secret")
-		return reconcile.Result{}, err
+		return err
 	}
+	objectreferencesv1.SetObjectReference(&instance.Status.RelatedObjects, *secretRef)
 
-	// Add the condition and relatedObject, but only update the status once
+	// add condition to status
 	conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
 		Type:    midasv1alpha1.ConditionCredentialsFound,
 		Status:  corev1.ConditionTrue,
 		Reason:  "SecretFound",
-		Message: fmt.Sprintf("A secret with the name %v in namespace %v was found", secretName, request.Namespace),
+		Message: fmt.Sprintf("A secret with the name %v in namespace %v was found", secretName, instance.Namespace),
 	})
-	objectreferencesv1.SetObjectReference(&instance.Status.RelatedObjects, *secretRef)
-	err = r.client.Status().Update(context.TODO(), instance)
-	if err != nil {
-		reqLogger.Error(err, "Failed to add secret to related objects")
-		return reconcile.Result{}, err
-	}
 
 	// Set BaremetalAsset instance as the owner and controller
 	if secret.OwnerReferences == nil || len(secret.OwnerReferences) == 0 {
 		if err := controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
 			reqLogger.Error(err, "Failed to set ControllerReference")
-			return reconcile.Result{}, err
+			return err
 		}
 		if err := r.client.Update(context.TODO(), secret); err != nil {
 			reqLogger.Error(err, "Failed to update secret with OwnerReferences")
-			return reconcile.Result{}, err
+			return err
 		}
 	}
+	return nil
+}
 
-	// Update the cluster label from instance spec.clusterName
-	// If not specified, removes the label.
-	updateLabels := false
-	clusterName := instance.Spec.ClusterDeployment.Name
-	clusterNamespace := instance.Spec.ClusterDeployment.Namespace
-	if instance.Labels[ClusterDeploymentNameLabel] != clusterName {
-		setLabel(instance, ClusterDeploymentNameLabel, clusterName)
-		setLabel(instance, ClusterDeploymentNamespaceLabel, clusterNamespace)
-		updateLabels = true
-	}
-	// Update the role label from instance spec.role
-	// If not specified, removes the label
-	if instance.Labels[RoleLabel] != fmt.Sprintf("%v", instance.Spec.Role) {
-		setLabel(instance, RoleLabel, fmt.Sprintf("%v", instance.Spec.Role))
-		updateLabels = true
-	}
-	if updateLabels {
-		if err := r.client.Update(context.TODO(), instance); err != nil {
-			reqLogger.Error(err, "Failed to update instance with cluster and role label")
-			return reconcile.Result{}, err
-		}
-	}
+func (r *ReconcileBareMetalAsset) ensureLabels(instance *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) error {
+	labels := k8slabels.CloneAndAddLabel(instance.Labels, ClusterDeploymentNameLabel, instance.Spec.ClusterDeployment.Name)
+	labels = k8slabels.AddLabel(labels, ClusterDeploymentNamespaceLabel, instance.Spec.ClusterDeployment.Namespace)
+	labels = k8slabels.AddLabel(labels, RoleLabel, string(instance.Spec.Role))
 
-	if clusterName != "" {
-		// If clusterName is specified in the spec, we need to find the clusterdeployment for that clusterName and create
-		// hive syncset in the same namespace as the clusterdeployment.
-		foundCd := &hivev1.ClusterDeployment{}
-		err = r.client.Get(context.TODO(), types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, foundCd)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				reqLogger.Error(err, "ClusterDeployment not found", "Namespace", clusterNamespace, "ClusterDeployment", clusterName)
-				conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
-					Type:    midasv1alpha1.ConditionClusterDeploymentFound,
-					Status:  corev1.ConditionFalse,
-					Reason:  "ClusterDeploymentNotFound",
-					Message: fmt.Sprintf("A cluster deployment with the name %v in namespace %v could not be found", clusterName, clusterNamespace),
-				})
-				return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
-			}
-			return reconcile.Result{}, err
-		}
+	if !reflect.DeepEqual(labels, instance.Labels) {
+		instance.Labels = labels
+		return r.client.Update(context.TODO(), instance)
+	}
+	return nil
+}
+
+// checkClusterDeployment verifies that we can find the ClusterDeployment specified in the BareMetalAsset
+func (r *ReconcileBareMetalAsset) checkClusterDeployment(instance *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) error {
+	clusterDeploymentName := instance.Spec.ClusterDeployment.Name
+	clusterDeploymentNamespace := instance.Spec.ClusterDeployment.Namespace
+
+	// if the clusterDeploymentName is not specified, we need to handle the possibility
+	// that it has been removed from the spec
+	if clusterDeploymentName == "" {
 		conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
 			Type:    midasv1alpha1.ConditionClusterDeploymentFound,
-			Status:  corev1.ConditionTrue,
-			Reason:  "ClusterDeploymentFound",
-			Message: fmt.Sprintf("A clusterdeployment with the name %v in namespace %v was found", clusterName, clusterNamespace),
+			Status:  corev1.ConditionFalse,
+			Reason:  "NoneSpecified",
+			Message: "No cluster deployment specified",
 		})
-		statusErr := r.client.Status().Update(context.TODO(), instance)
-		if statusErr != nil {
-			reqLogger.Error(statusErr, "Failed to update instance status")
-			return reconcile.Result{}, statusErr
-		}
+		conditionsv1.RemoveStatusCondition(&instance.Status.Conditions, midasv1alpha1.ConditionAssetSyncStarted)
+		conditionsv1.RemoveStatusCondition(&instance.Status.Conditions, midasv1alpha1.ConditionAssetSyncCompleted)
 
-		// If clusterDeployment is found, ensure syncset is created
-		err = r.ensureHiveSyncSet(instance, foundCd, reqLogger)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-	} else {
 		// Without a clusterName, we do not know what namespace the syncset is in.
 		// Get the syncset from relatedobjects if it exists
 		hscRef := corev1.ObjectReference{}
@@ -280,11 +290,12 @@ func (r *ReconcileBareMetalAsset) Reconcile(request reconcile.Request) (reconcil
 		}
 		if hscRef == (corev1.ObjectReference{}) {
 			// No syncset found in relatedObjects. Nothing to do.
-			return reconcile.Result{}, nil
+			return bmaerrors.NewNoClusterError()
 		}
+
 		// If clusterName is not specified, delete the syncset if it exists
-		reqLogger.Info("Cleaning up Hive SyncSet", "Name", hscRef.Name, "Namespace", hscRef.Namespace)
-		err = r.client.Delete(context.TODO(), &hivev1.SyncSet{
+		reqLogger.Info("Cleaning up Hive SyncSet", "SyncSet.Name", hscRef.Name, "SyncSet.Namespace", hscRef.Namespace)
+		err := r.client.Delete(context.TODO(), &hivev1.SyncSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: hscRef.Namespace,
 				Name:      hscRef.Name,
@@ -293,127 +304,45 @@ func (r *ReconcileBareMetalAsset) Reconcile(request reconcile.Request) (reconcil
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				reqLogger.Error(err, "Failed to delete Hive SyncSet")
-				return reconcile.Result{}, err
+				return err
 			}
 		}
+
 		// Remove SyncSet from related objects
 		objectreferencesv1.RemoveObjectReference(&instance.Status.RelatedObjects, hscRef)
-		return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
+		return bmaerrors.NewNoClusterError()
 	}
 
-	reqLogger.Info("Reconciled")
-
-	return reconcile.Result{}, nil
-}
-
-func (r *ReconcileBareMetalAsset) checkHiveSyncSetInstance(bma *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) error {
-	found := &hivev1.SyncSetInstanceList{}
-	err := r.client.List(context.TODO(), found, client.MatchingLabels{hiveconstants.SyncSetNameLabel: bma.Name})
-
+	// If a clusterDeployment is specified, we need to find it
+	cd := &hivev1.ClusterDeployment{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: clusterDeploymentName, Namespace: clusterDeploymentNamespace}, cd)
 	if err != nil {
-		reqLogger.Error(err, "Problem getting Hive SyncSetInstanceList")
+		if errors.IsNotFound(err) {
+			reqLogger.Error(err, "ClusterDeployment not found", "ClusterDeployment.Name", clusterDeploymentName, "ClusterDeployment.Namespace", clusterDeploymentNamespace)
+			conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+				Type:    midasv1alpha1.ConditionClusterDeploymentFound,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ClusterDeploymentNotFound",
+				Message: err.Error(),
+			})
+			return err
+		}
 		return err
 	}
-	switch len(found.Items) {
-	case 0:
-		err = fmt.Errorf("No SyncSetInstances with label name %v and label value %v found", hiveconstants.SyncSetNameLabel, bma.Name)
-		conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-			Type:    midasv1alpha1.ConditionAssetSyncCompleted,
-			Status:  corev1.ConditionFalse,
-			Reason:  "SyncSetInstanceNotFound",
-			Message: err.Error(),
-		})
-		return err
-	case 1:
-		resourceCount := len(found.Items[0].Status.Resources)
-		if resourceCount != 1 {
-			err = fmt.Errorf("Unexpected number of resources found on SyncSetInstance status. Expected (%v) Found (%v)", 1, resourceCount)
-			conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-				Type:    midasv1alpha1.ConditionAssetSyncCompleted,
-				Status:  corev1.ConditionFalse,
-				Reason:  "UnexpectedResourceCount",
-				Message: err.Error(),
-			})
-			return err
-		}
-		res := found.Items[0].Status.Resources[0]
-		if res.APIVersion != metal3v1alpha1.SchemeGroupVersion.String() || res.Kind != BareMetalHostKind {
-			err = fmt.Errorf("Unexpected resource found in SyncSetInstance status. Expected (Kind: %v APIVersion: %v) Found (Kind: %v APIVersion: %v)", BareMetalHostKind, metal3v1alpha1.SchemeGroupVersion.String(), res.Kind, res.APIVersion)
-			conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-				Type:    midasv1alpha1.ConditionAssetSyncCompleted,
-				Status:  corev1.ConditionFalse,
-				Reason:  "BareMetalHostResourceNotFound",
-				Message: err.Error(),
-			})
-			return err
-		}
-		for _, condition := range res.Conditions {
-			switch condition.Type {
-			case hivev1.ApplySuccessSyncCondition:
-				conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-					Type:    midasv1alpha1.ConditionAssetSyncCompleted,
-					Status:  condition.Status,
-					Reason:  condition.Reason,
-					Message: condition.Message,
-				})
-			case hivev1.ApplyFailureSyncCondition:
-				conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-					Type:    midasv1alpha1.ConditionAssetSyncCompleted,
-					Status:  corev1.ConditionFalse,
-					Reason:  condition.Reason,
-					Message: condition.Message,
-				})
-				return fmt.Errorf("SyncSetInstance resource %v failed with message %v", res.Name, condition.Message)
-			}
-		}
 
-		secretsCount := len(found.Items[0].Status.Secrets)
-		if secretsCount != 1 {
-			err = fmt.Errorf("Unexpected number of secrets found on SyncSetInstance. Expected: (%v) Actual: (%v)", 1, secretsCount)
-			conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-				Type:    midasv1alpha1.ConditionAssetSyncCompleted,
-				Status:  corev1.ConditionFalse,
-				Reason:  "UnexpectedSecretCount",
-				Message: err.Error(),
-			})
-			return err
-		}
-		secret := found.Items[0].Status.Secrets[0]
-		for _, condition := range secret.Conditions {
-			switch condition.Type {
-			case hivev1.ApplySuccessSyncCondition:
-				conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-					Type:    midasv1alpha1.ConditionAssetSyncCompleted,
-					Status:  condition.Status,
-					Reason:  condition.Reason,
-					Message: condition.Message,
-				})
-			case hivev1.ApplyFailureSyncCondition:
-				conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-					Type:    midasv1alpha1.ConditionAssetSyncCompleted,
-					Status:  corev1.ConditionFalse,
-					Reason:  condition.Reason,
-					Message: condition.Message,
-				})
-				return fmt.Errorf("SyncSetInstance resource %v failed with message %v", res.Name, condition.Message)
-			}
-		}
-	default:
-		err = fmt.Errorf("Found multiple Hive SyncSetInstances with same label")
-		conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-			Type:    midasv1alpha1.ConditionAssetSyncCompleted,
-			Status:  corev1.ConditionFalse,
-			Reason:  "MultipleSyncSetInstancesFound",
-			Message: err.Error(),
-		})
-		return err
-	}
+	// add condition
+	conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+		Type:    midasv1alpha1.ConditionClusterDeploymentFound,
+		Status:  corev1.ConditionTrue,
+		Reason:  "ClusterDeploymentFound",
+		Message: fmt.Sprintf("A ClusterDeployment with the name %v in namespace %v was found", cd.Name, cd.Namespace),
+	})
+
 	return nil
 }
 
-func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetalAsset, cd *hivev1.ClusterDeployment, reqLogger logr.Logger) error {
-	hsc := r.newHiveSyncSet(bma, cd, reqLogger)
-
+func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(instance *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) error {
+	hsc := r.newHiveSyncSet(instance, reqLogger)
 	found := &hivev1.SyncSet{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: hsc.Name, Namespace: hsc.Namespace}, found)
 	if err != nil {
@@ -421,67 +350,31 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetal
 			err := r.client.Create(context.TODO(), hsc)
 			if err != nil {
 				reqLogger.Error(err, "Failed to create Hive SyncSet")
-				conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
+				conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
 					Type:    midasv1alpha1.ConditionAssetSyncStarted,
 					Status:  corev1.ConditionFalse,
 					Reason:  "SyncSetCreationFailed",
 					Message: "Failed to create SyncSet",
 				})
-				// do not overwrite err
-				serr := r.client.Status().Update(context.TODO(), bma)
-				if serr != nil {
-					reqLogger.Error(serr, "Failed to update SyncSetCreated condition")
-				}
 				return err
 			}
 
-			conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
+			conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
 				Type:    midasv1alpha1.ConditionAssetSyncStarted,
 				Status:  corev1.ConditionTrue,
 				Reason:  "SyncSetCreated",
 				Message: "SyncSet created successfully",
 			})
-		} else {
-			// other error. fail reconcile
-			reqLogger.Error(err, "Failed to get Hive SyncSet")
-			return err
 		}
-	} else {
-		updateLabels := false
-		// Update Hive SyncSet cluster label if it is not in desired state
-		if found.Labels[ClusterDeploymentNameLabel] != bma.Spec.ClusterDeployment.Name {
-			setLabel(found, ClusterDeploymentNameLabel, bma.Spec.ClusterDeployment.Name)
-			setLabel(found, ClusterDeploymentNamespaceLabel, bma.Spec.ClusterDeployment.Namespace)
-			updateLabels = true
-		}
-		// Update Hive SyncSet role label if it is not in desired state
-		if found.Labels[RoleLabel] != fmt.Sprintf("%v", bma.Spec.Role) {
-			setLabel(found, RoleLabel, fmt.Sprintf("%v", bma.Spec.Role))
-			updateLabels = true
-		}
-		if updateLabels {
-			if err := r.client.Update(context.TODO(), found); err != nil {
-				reqLogger.Error(err, "Failed to update Hive SyncSet with cluster and role label")
-				return err
-			}
-		}
-
-		// Update Hive SyncSet CR if it is not in the desired state
-		if !reflect.DeepEqual(hsc.Spec, found.Spec) {
-			reqLogger.Info("Updating spec for Hive SyncSet")
-			found.Spec = hsc.Spec
-			err := r.client.Update(context.TODO(), found)
-			if err != nil {
-				reqLogger.Error(err, "Failed to update Hive SyncSet")
-				return err
-			}
-			conditionsv1.SetStatusCondition(&bma.Status.Conditions, conditionsv1.Condition{
-				Type:    midasv1alpha1.ConditionAssetSyncStarted,
-				Status:  corev1.ConditionTrue,
-				Reason:  "SyncSetUpdated",
-				Message: "SyncSet updated successfully",
-			})
-		}
+		// other error. fail reconcile
+		conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+			Type:    midasv1alpha1.ConditionAssetSyncStarted,
+			Status:  corev1.ConditionFalse,
+			Reason:  "SyncSetGetFailed",
+			Message: "Failed to get SyncSet",
+		})
+		reqLogger.Error(err, "Failed to get Hive SyncSet", "SyncSet.Name", hsc.Name, "SyncSet.Namespace", hsc.Namespace)
+		return err
 	}
 
 	// Add SyncSet to related objects
@@ -490,22 +383,41 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(bma *midasv1alpha1.BareMetal
 		reqLogger.Error(err, "Failed to get reference from SyncSet")
 		return err
 	}
-	objectreferencesv1.SetObjectReference(&bma.Status.RelatedObjects, *hscRef)
+	objectreferencesv1.SetObjectReference(&instance.Status.RelatedObjects, *hscRef)
 
-	err = r.checkHiveSyncSetInstance(bma, reqLogger)
-	if err != nil {
-		reqLogger.Error(err, "Failed to get asset sync update from Hive SyncSetInstance")
-		statusError := r.client.Status().Update(context.TODO(), bma)
-		if statusError != nil {
-			reqLogger.Error(statusError, "Error while updating status")
+	// Add labels to copy for comparison to minimize updates
+	labels := k8slabels.CloneAndAddLabel(found.Labels, ClusterDeploymentNameLabel, instance.Spec.ClusterDeployment.Name)
+	labels = k8slabels.AddLabel(labels, ClusterDeploymentNamespaceLabel, instance.Spec.ClusterDeployment.Namespace)
+	labels = k8slabels.AddLabel(labels, RoleLabel, string(instance.Spec.Role))
+
+	// Update Hive SyncSet CR if it is not in the desired state
+	if !reflect.DeepEqual(hsc.Spec, found.Spec) || !reflect.DeepEqual(labels, found.Labels) {
+		reqLogger.Info("Updating Hive SyncSet", "SyncSet.Name", hsc.Name, "SyncSet.Namespace", hsc.Namespace)
+		found.Spec = hsc.Spec
+		found.Labels = labels
+		err := r.client.Update(context.TODO(), found)
+		if err != nil {
+			reqLogger.Error(err, "Failed to update Hive SyncSet", "SyncSet.Name", hsc.Name, "SyncSet.Namespace", hsc.Namespace)
+			conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+				Type:    midasv1alpha1.ConditionAssetSyncStarted,
+				Status:  corev1.ConditionFalse,
+				Reason:  "SyncSetUpdateFailed",
+				Message: "Failed to update SyncSet",
+			})
+			return err
 		}
-		return err
+		conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+			Type:    midasv1alpha1.ConditionAssetSyncStarted,
+			Status:  corev1.ConditionTrue,
+			Reason:  "SyncSetUpdated",
+			Message: "SyncSet updated successfully",
+		})
 	}
-	return r.client.Status().Update(context.TODO(), bma)
+	return nil
 }
 
-func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAsset, cd *hivev1.ClusterDeployment, reqLogger logr.Logger) *hivev1.SyncSet {
-	bmhResource, err := json.Marshal(r.newBareMetalHost(bma, reqLogger))
+func (r *ReconcileBareMetalAsset) newHiveSyncSet(instance *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) *hivev1.SyncSet {
+	bmhJSON, err := json.Marshal(r.newBareMetalHost(instance, reqLogger))
 	if err != nil {
 		reqLogger.Error(err, "Error marshaling baremetalhost")
 		return nil
@@ -520,24 +432,29 @@ func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAss
 			APIVersion: "hive.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      bma.Name,
-			Namespace: cd.Namespace, // syncset should be created in the same namespace as the clusterdeployment
+			Name:      instance.Name,
+			Namespace: instance.Spec.ClusterDeployment.Namespace, // syncset should be created in the same namespace as the clusterdeployment
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
-					UID:                bma.UID,
-					APIVersion:         bma.APIVersion,
-					Kind:               bma.Kind,
-					Name:               bma.Name,
+					UID:                instance.UID,
+					APIVersion:         instance.APIVersion,
+					Kind:               instance.Kind,
+					Name:               instance.Name,
 					BlockOwnerDeletion: &blockOwnerDeletion,
 					Controller:         &isController,
 				},
+			},
+			Labels: map[string]string{
+				ClusterDeploymentNameLabel:      instance.Spec.ClusterDeployment.Name,
+				ClusterDeploymentNamespaceLabel: instance.Spec.ClusterDeployment.Namespace,
+				RoleLabel:                       string(instance.Spec.Role),
 			},
 		},
 		Spec: hivev1.SyncSetSpec{
 			SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
 				Resources: []runtime.RawExtension{
 					{
-						Raw: bmhResource,
+						Raw: bmhJSON,
 					},
 				},
 				Patches:           []hivev1.SyncObjectPatch{},
@@ -545,11 +462,11 @@ func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAss
 				Secrets: []hivev1.SecretMapping{
 					hivev1.SecretMapping{
 						SourceRef: hivev1.SecretReference{
-							Name:      bma.Spec.BMC.CredentialsName,
-							Namespace: bma.Namespace,
+							Name:      instance.Spec.BMC.CredentialsName,
+							Namespace: instance.Namespace,
 						},
 						TargetRef: hivev1.SecretReference{
-							Name:      bma.Spec.BMC.CredentialsName,
+							Name:      instance.Spec.BMC.CredentialsName,
 							Namespace: midasv1alpha1.ManagedClusterResourceNamespace,
 						},
 					},
@@ -557,54 +474,143 @@ func (r *ReconcileBareMetalAsset) newHiveSyncSet(bma *midasv1alpha1.BareMetalAss
 			},
 			ClusterDeploymentRefs: []corev1.LocalObjectReference{
 				{
-					Name: bma.Spec.ClusterDeployment.Name,
+					Name: instance.Spec.ClusterDeployment.Name,
 				},
 			},
 		},
 	}
-	setLabel(hsc, ClusterDeploymentNameLabel, bma.Spec.ClusterDeployment.Name)
-	setLabel(hsc, ClusterDeploymentNamespaceLabel, bma.Spec.ClusterDeployment.Namespace)
-	setLabel(hsc, RoleLabel, fmt.Sprintf("%v", bma.Spec.Role))
 	return hsc
 }
 
-func (r *ReconcileBareMetalAsset) newBareMetalHost(bma *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) *metal3v1alpha1.BareMetalHost {
+func (r *ReconcileBareMetalAsset) newBareMetalHost(instance *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) *metal3v1alpha1.BareMetalHost {
 	bmh := &metal3v1alpha1.BareMetalHost{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       BareMetalHostKind,
 			APIVersion: metal3v1alpha1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      bma.Name,
+			Name:      instance.Name,
 			Namespace: midasv1alpha1.ManagedClusterResourceNamespace,
+			Labels: map[string]string{
+				ClusterDeploymentNameLabel:      instance.Spec.ClusterDeployment.Name,
+				ClusterDeploymentNamespaceLabel: instance.Spec.ClusterDeployment.Namespace,
+				RoleLabel:                       string(instance.Spec.Role),
+			},
 		},
 		Spec: metal3v1alpha1.BareMetalHostSpec{
 			BMC: metal3v1alpha1.BMCDetails{
-				Address:         bma.Spec.BMC.Address,
-				CredentialsName: bma.Spec.BMC.CredentialsName,
+				Address:         instance.Spec.BMC.Address,
+				CredentialsName: instance.Spec.BMC.CredentialsName,
 			},
-			HardwareProfile: bma.Spec.HardwareProfile,
-			BootMACAddress:  bma.Spec.BootMACAddress,
+			HardwareProfile: instance.Spec.HardwareProfile,
+			BootMACAddress:  instance.Spec.BootMACAddress,
 		},
 	}
-	setLabel(bmh, ClusterDeploymentNameLabel, bma.Spec.ClusterDeployment.Name)
-	setLabel(bmh, ClusterDeploymentNamespaceLabel, bma.Spec.ClusterDeployment.Namespace)
-	setLabel(bmh, RoleLabel, fmt.Sprintf("%v", bma.Spec.Role))
 	return bmh
 }
 
-// Set the label on the given object.
-// If key exists, value is overridden/updated.
-// If value is nil, key is deleted.
-func setLabel(object metav1.Object, key string, value string) {
-	labels := object.GetLabels()
-	if labels == nil {
-		labels = map[string]string{}
+func (r *ReconcileBareMetalAsset) checkHiveSyncSetInstance(instance *midasv1alpha1.BareMetalAsset, reqLogger logr.Logger) error {
+	found := &hivev1.SyncSetInstanceList{}
+
+	err := r.client.List(context.TODO(), found, client.MatchingLabels{hiveconstants.SyncSetNameLabel: instance.Name})
+	if err != nil {
+		reqLogger.Error(err, "Problem getting Hive SyncSetInstanceList", "Label.Key", hiveconstants.SyncSetNameLabel, "Label.Value", instance.Name)
+		return err
 	}
-	if value != "" {
-		labels[key] = value
-	} else {
-		delete(labels, key)
+
+	switch len(found.Items) {
+	case 0:
+		err = fmt.Errorf("No SyncSetInstances with label name %v and label value %v found", hiveconstants.SyncSetNameLabel, instance.Name)
+		conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+			Type:    midasv1alpha1.ConditionAssetSyncCompleted,
+			Status:  corev1.ConditionFalse,
+			Reason:  "SyncSetInstanceNotFound",
+			Message: err.Error(),
+		})
+		return err
+	case 1:
+		resourceCount := len(found.Items[0].Status.Resources)
+		if resourceCount != 1 {
+			err = fmt.Errorf("Unexpected number of resources found on SyncSetInstance status. Expected (%v) Found (%v)", 1, resourceCount)
+			conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+				Type:    midasv1alpha1.ConditionAssetSyncCompleted,
+				Status:  corev1.ConditionFalse,
+				Reason:  "UnexpectedResourceCount",
+				Message: err.Error(),
+			})
+			return err
+		}
+		res := found.Items[0].Status.Resources[0]
+		if res.APIVersion != metal3v1alpha1.SchemeGroupVersion.String() || res.Kind != BareMetalHostKind {
+			err = fmt.Errorf("Unexpected resource found in SyncSetInstance status. Expected (Kind: %v APIVersion: %v) Found (Kind: %v APIVersion: %v)", BareMetalHostKind, metal3v1alpha1.SchemeGroupVersion.String(), res.Kind, res.APIVersion)
+			conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+				Type:    midasv1alpha1.ConditionAssetSyncCompleted,
+				Status:  corev1.ConditionFalse,
+				Reason:  "BareMetalHostResourceNotFound",
+				Message: err.Error(),
+			})
+			return err
+		}
+		for _, condition := range res.Conditions {
+			switch condition.Type {
+			case hivev1.ApplySuccessSyncCondition:
+				conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+					Type:    midasv1alpha1.ConditionAssetSyncCompleted,
+					Status:  condition.Status,
+					Reason:  condition.Reason,
+					Message: condition.Message,
+				})
+			case hivev1.ApplyFailureSyncCondition:
+				conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+					Type:    midasv1alpha1.ConditionAssetSyncCompleted,
+					Status:  corev1.ConditionFalse,
+					Reason:  condition.Reason,
+					Message: condition.Message,
+				})
+				return fmt.Errorf("SyncSetInstance resource %v failed with message %v", res.Name, condition.Message)
+			}
+		}
+
+		secretsCount := len(found.Items[0].Status.Secrets)
+		if secretsCount != 1 {
+			err = fmt.Errorf("Unexpected number of secrets found on SyncSetInstance. Expected: (%v) Actual: (%v)", 1, secretsCount)
+			conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+				Type:    midasv1alpha1.ConditionAssetSyncCompleted,
+				Status:  corev1.ConditionFalse,
+				Reason:  "UnexpectedSecretCount",
+				Message: err.Error(),
+			})
+			return err
+		}
+		secret := found.Items[0].Status.Secrets[0]
+		for _, condition := range secret.Conditions {
+			switch condition.Type {
+			case hivev1.ApplySuccessSyncCondition:
+				conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+					Type:    midasv1alpha1.ConditionAssetSyncCompleted,
+					Status:  condition.Status,
+					Reason:  condition.Reason,
+					Message: condition.Message,
+				})
+			case hivev1.ApplyFailureSyncCondition:
+				conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+					Type:    midasv1alpha1.ConditionAssetSyncCompleted,
+					Status:  corev1.ConditionFalse,
+					Reason:  condition.Reason,
+					Message: condition.Message,
+				})
+				return fmt.Errorf("SyncSetInstance resource %v failed with message %v", res.Name, condition.Message)
+			}
+		}
+	default:
+		err = fmt.Errorf("Found multiple Hive SyncSetInstances with same label")
+		conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
+			Type:    midasv1alpha1.ConditionAssetSyncCompleted,
+			Status:  corev1.ConditionFalse,
+			Reason:  "MultipleSyncSetInstancesFound",
+			Message: err.Error(),
+		})
+		return err
 	}
-	object.SetLabels(labels)
+	return nil
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,53 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// NoClusterSpecifiedError is an error when no cluster is specified
+type NoClusterSpecifiedError struct {
+	Message string
+}
+
+// Error returns a string representation of the NoClusterSpecifiedError
+func (e NoClusterSpecifiedError) Error() string {
+	return e.Message
+}
+
+// NewNoClusterError returns a NoClusterSpecifiedError
+func NewNoClusterError() error {
+	return &NoClusterSpecifiedError{
+		Message: "No cluster specified",
+	}
+}
+
+// IsNoClusterError returns true if the err is a NoClusterSpecifiedError
+func IsNoClusterError(err error) bool {
+	_, ok := err.(*NoClusterSpecifiedError)
+	return ok
+}
+
+// AssetSecretNotFoundError is an error when the asset's secret can not be found
+type AssetSecretNotFoundError struct {
+	Name      string
+	Namespace string
+}
+
+// Error returns a string representation of the AssetSecretNotFoundError
+func (e AssetSecretNotFoundError) Error() string {
+	return fmt.Sprintf("Secret %v not found in namespace %v", e.Name, e.Namespace)
+}
+
+// NewAssetSecretNotFoundError returns a AssetSecretNotFoundError
+func NewAssetSecretNotFoundError(name, namespace string) error {
+	return &AssetSecretNotFoundError{
+		Name:      name,
+		Namespace: namespace,
+	}
+}
+
+// IsAssetSecretNotFoundError returns true if the err is a AssetSecretNotFoundError
+func IsAssetSecretNotFoundError(err error) bool {
+	_, ok := err.(*AssetSecretNotFoundError)
+	return ok
+}


### PR DESCRIPTION
Break the reconcile function into it's component pieces and proceed
through the steps in order.

The goal is to limit the number of API calls we make by proceeding as
far as we can go before we run into an error (or none) and update the
status as the last step. This limits the amount of error handling we
need to do for simple status updates.