### PR TITLE
Adding required roles for syncsetinstances

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -59,6 +59,14 @@ rules:
 - apiGroups:
   - hive.openshift.io
   resources:
+  - syncsetinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
   - clusterdeployments
   verbs:
   - get


### PR DESCRIPTION
We fetch syncsetinstances in order to get the sync status of the resources.

Fixes #23 and #24 